### PR TITLE
Add fill colors to carbon charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -926,7 +926,7 @@ export default function PromiseXSimulator() {
                                 <Tooltip
                                   contentStyle={{ background: "#0b1220", border: "1px solid #334155", color: palette.text }}
                                 />
-                                <Bar {...animFast} isAnimationActive={animate} dataKey="CO2" />
+                                <Bar {...animFast} isAnimationActive={animate} dataKey="CO2" fill={palette.line} />
                               </BarChart>
                             </ResponsiveContainer>
                           </div>
@@ -1385,6 +1385,7 @@ export default function PromiseXSimulator() {
                             yAxisId="left"
                             dataKey="CO2"
                             name="CO₂ kg"
+                            fill={palette.area}
                           />
                           <Bar
                             {...animFast}
@@ -1392,6 +1393,7 @@ export default function PromiseXSimulator() {
                             yAxisId="right"
                             dataKey="OTP"
                             name="OTP %"
+                            fill={palette.line}
                           />
                         </BarChart>
                       </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- add palette styling to carbon comparison bar
- add palette styling for CO₂ and OTP bars in contract chart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1c5d1e0833095d0b45fbe2aec92