### PR TITLE
Adjust Top drivers chart layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -974,9 +974,9 @@ export default function PromiseXSimulator() {
                             <Cog className="w-4 h-4" /> Top drivers
                           </CardTitle>
                         </CardHeader>
-                        <CardContent className="h-32">
+                        <CardContent className="h-40">
                           <ResponsiveContainer width="100%" height="100%">
-                            <PieChart>
+                            <PieChart margin={{ top: 0, bottom: 24 }}>
                               <Pie
                                 {...animFast}
                                 isAnimationActive={animate}
@@ -994,7 +994,12 @@ export default function PromiseXSimulator() {
                                 contentStyle={{ background: "#0b1220", border: "1px solid #334155", color: palette.text }}
                                 formatter={(v: any, n: any) => [`${fmtPct(v as number)}`, n as string]}
                               />
-                              <Legend wrapperStyle={{ color: palette.text }} />
+                              <Legend
+                                verticalAlign="bottom"
+                                layout="horizontal"
+                                height={32}
+                                wrapperStyle={{ color: palette.text }}
+                              />
                             </PieChart>
                           </ResponsiveContainer>
                         </CardContent>


### PR DESCRIPTION
## Summary
- expand Top drivers card to allow space for legend
- show chart legend below pie chart with extra margin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b9835004833093ad83eae693bb87